### PR TITLE
Add descriptive adafruit io username/text comment

### DIFF
--- a/adafruit-io/hologram-mqtt-client.ino
+++ b/adafruit-io/hologram-mqtt-client.ino
@@ -42,13 +42,16 @@ const char pass[] = "";
 
 // MQTT details
 const char* broker = "io.adafruit.com";
-
 #define CLIENT_ID "gsmArduino"
-#define ADAFRUIT_USERNAME ""
-#define AIO_KEY ""
+
+// visit io.adafruit.com if you need to create an account,
+// or if you need your Adafruit IO key.
+#define ADAFRUIT_USERNAME    "your_username"
+#define AIO_KEY              "your_key"
+
+// Adafruit IO Feeds
 #define SUBSCRIBE_FEED_PATH ADAFRUIT_USERNAME "/feeds/hologram.from"
 #define PUBLISH_FEED_PATH ADAFRUIT_USERNAME "/feeds/hologram.to"
-
 
 
 TinyGsm modem(SerialAT);


### PR DESCRIPTION
Sometimes it's hard for a new user to find the username/aio key, called it out in your code like we do in the AdafruitIO_Arduino library examples